### PR TITLE
Added patito model to dagster type convertor

### DIFF
--- a/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/__init__.py
@@ -2,6 +2,7 @@ from dagster._core.libraries import DagsterLibraryRegistry
 
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
 from dagster_polars.io_managers.parquet import PolarsParquetIOManager
+from dagster_polars.io_managers.type_checks import patito_model_to_dagster_type
 from dagster_polars.types import DataFramePartitions, LazyFramePartitions
 from dagster_polars.version import __version__
 
@@ -10,6 +11,7 @@ __all__ = [
     "DataFramePartitions",
     "LazyFramePartitions",
     "PolarsParquetIOManager",
+    "patito_model_to_dagster_type",
     "__version__",
 ]
 

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/__init__.py
@@ -1,9 +1,11 @@
 from dagster_polars.io_managers.base import BasePolarsUPathIOManager
 from dagster_polars.io_managers.parquet import PolarsParquetIOManager
+from dagster_polars.io_managers.type_checks import patito_model_to_dagster_type
 
 __all__ = [
     "BasePolarsUPathIOManager",
     "PolarsParquetIOManager",
+    "patito_model_to_dagster_type",
 ]
 
 

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
@@ -16,7 +16,8 @@ from dagster import (
 VALID_DATAFRAME_CLASSES = (pl.DataFrame,)
 
 
-def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa: ANN401
+# TODO: look into a better way to get the asset name and pass it to this function
+def patito_model_to_dagster_type(model: pt.Model | Any, asset_name: str) -> DagsterType:  # noqa: ANN401
     """Convert patito model to dagster type checking.
 
     Args:
@@ -31,7 +32,7 @@ def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa:
         col_1: str | None
         col_2: int = pt.Field(unique=True)
 
-    @asset(dagster_type=patito_model_to_dagster_type(MyTable),
+    @asset(dagster_type=patito_model_to_dagster_type(MyTable, "my_asset"),
         io_manager_key="my_io_manager")
     def my_asset() -> pl.DataFrame:
         return pl.DataFrame({
@@ -41,8 +42,8 @@ def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa:
     ```
     """
     table_columns = []
-    schema_dtypes: dict = model.dtypes  # type: ignore
-    column_infos: dict = model.column_infos  # type: ignore
+    schema_dtypes: dict = model.dtypes
+    column_infos: dict = model.column_infos
 
     for col, properties in model._schema_properties().items():
         table_columns.append(
@@ -54,7 +55,7 @@ def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa:
                     if column_infos[col].unique is not None
                     else False,
                     nullable="anyOf" in properties,
-                    # TODO(ion): Handle Other constraints, serialize the expressions
+                    # TODO: Handle Other constraints, serialize the expressions
                 ),
             ),
         )
@@ -63,7 +64,7 @@ def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa:
     type_check_fn = _patito_model_to_type_check_fn(model)
     return DagsterType(
         type_check_fn=type_check_fn,
-        name="pl.DataFrame",
+        name=asset_name,
         metadata={
             "schema": MetadataValue.table_schema(table_schema),
         },

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
@@ -17,11 +17,17 @@ VALID_DATAFRAME_CLASSES = (pl.DataFrame,)
 
 
 # TODO: look into a better way to get the asset name and pass it to this function
-def patito_model_to_dagster_type(model: pt.Model | Any, asset_name: str) -> DagsterType:  # noqa: ANN401
+def patito_model_to_dagster_type(
+    model: pt.Model | Any,
+    dagster_type_suffix: str | None = None,
+    description: str | None = None,
+) -> DagsterType:  # noqa: ANN401
     """Convert patito model to dagster type checking.
 
     Args:
         model (pt.Model): validation model of frame
+        dagster_type_suffix (str): the dagster type name suffix, to avoid duplication of dagster type names in case of multiple assets sharing a patito model. Defaults to None
+        description (str): Dagster Type description
 
     Returns:
         DagsterType: Dagster type with patito validation fn
@@ -44,6 +50,7 @@ def patito_model_to_dagster_type(model: pt.Model | Any, asset_name: str) -> Dags
     table_columns = []
     schema_dtypes: dict = model.dtypes
     column_infos: dict = model.column_infos
+    description = f"Dagster Type constructor for Polars DataFrame conforming to Patito model {model.__class__.__name__}"
 
     for col, properties in model._schema_properties().items():
         table_columns.append(
@@ -64,11 +71,12 @@ def patito_model_to_dagster_type(model: pt.Model | Any, asset_name: str) -> Dags
     type_check_fn = _patito_model_to_type_check_fn(model)
     return DagsterType(
         type_check_fn=type_check_fn,
-        name=asset_name,
+        name=f"{model.__class__.__name__}-{dagster_type_suffix}",
         metadata={
             "schema": MetadataValue.table_schema(table_schema),
         },
         typing_type=pl.DataFrame,
+        description=description,
     )
 
 
@@ -79,15 +87,11 @@ def _patito_model_to_type_check_fn(
         if isinstance(value, VALID_DATAFRAME_CLASSES):
             try:
                 schema.validate(value)
+                return TypeCheck(success=True)
             except pt.DataFrameValidationError as e:
                 return TypeCheck(
                     success=False,
                     description=str(e),
-                )
-            except Exception as e:
-                return TypeCheck(
-                    success=False,
-                    description=f"Unexpected error during validation: {e}",
                 )
         else:
             return TypeCheck(
@@ -96,6 +100,5 @@ def _patito_model_to_type_check_fn(
                     f"Must be one of {VALID_DATAFRAME_CLASSES}, not {type(value).__name__}."
                 ),
             )
-        return TypeCheck(success=True)
 
     return type_check_fn

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
@@ -1,0 +1,100 @@
+from collections.abc import Callable
+from typing import Any
+
+import patito as pt
+import polars as pl
+from dagster import (
+    DagsterType,
+    MetadataValue,
+    TableColumn,
+    TableColumnConstraints,
+    TableSchema,
+    TypeCheck,
+    TypeCheckContext,
+)
+
+VALID_DATAFRAME_CLASSES = (pl.DataFrame,)
+
+
+def patito_model_to_dagster_type(model: pt.Model | Any) -> DagsterType:  # noqa: ANN401
+    """Convert patito model to dagster type checking.
+
+    Args:
+        model (pt.Model): validation model of frame
+
+    Returns:
+        DagsterType: Dagster type with patito validation fn
+
+    Example:
+    ```python
+    class MyTable(pt.Model):
+        col_1: str | None
+        col_2: int = pt.Field(unique=True)
+
+    @asset(dagster_type=patito_model_to_dagster_type(MyTable),
+        io_manager_key="my_io_manager")
+    def my_asset() -> pl.DataFrame:
+        return pl.DataFrame({
+            "col_1": ['a'],
+            "col_2": [2],
+        })
+    ```
+    """
+    table_columns = []
+    schema_dtypes: dict = model.dtypes  # type: ignore
+    column_infos: dict = model.column_infos  # type: ignore
+
+    for col, properties in model._schema_properties().items():
+        table_columns.append(
+            TableColumn(
+                name=col,
+                type=str(schema_dtypes[col]),
+                constraints=TableColumnConstraints(
+                    unique=column_infos[col].unique
+                    if column_infos[col].unique is not None
+                    else False,
+                    nullable="anyOf" in properties,
+                    # TODO(ion): Handle Other constraints, serialize the expressions
+                ),
+            ),
+        )
+    table_schema = TableSchema(columns=table_columns)
+
+    type_check_fn = _patito_model_to_type_check_fn(model)
+    return DagsterType(
+        type_check_fn=type_check_fn,
+        name="pl.DataFrame",
+        metadata={
+            "schema": MetadataValue.table_schema(table_schema),
+        },
+        typing_type=pl.DataFrame,
+    )
+
+
+def _patito_model_to_type_check_fn(
+    schema: pt.Model,
+) -> Callable[[TypeCheckContext, object], TypeCheck]:
+    def type_check_fn(context: TypeCheckContext, value: object) -> TypeCheck:  # noqa: ARG001
+        if isinstance(value, VALID_DATAFRAME_CLASSES):
+            try:
+                schema.validate(value)
+            except pt.DataFrameValidationError as e:
+                return TypeCheck(
+                    success=False,
+                    description=str(e),
+                )
+            except Exception as e:
+                return TypeCheck(
+                    success=False,
+                    description=f"Unexpected error during validation: {e}",
+                )
+        else:
+            return TypeCheck(
+                success=False,
+                description=(
+                    f"Must be one of {VALID_DATAFRAME_CLASSES}, not {type(value).__name__}."
+                ),
+            )
+        return TypeCheck(success=True)
+
+    return type_check_fn

--- a/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars/io_managers/type_checks.py
@@ -19,7 +19,6 @@ VALID_DATAFRAME_CLASSES = (pl.DataFrame,)
 # TODO: look into a better way to get the asset name and pass it to this function
 def patito_model_to_dagster_type(
     model: pt.Model | Any,
-    dagster_type_suffix: str | None = None,
     description: str | None = None,
 ) -> DagsterType:  # noqa: ANN401
     """Convert patito model to dagster type checking.
@@ -71,7 +70,7 @@ def patito_model_to_dagster_type(
     type_check_fn = _patito_model_to_type_check_fn(model)
     return DagsterType(
         type_check_fn=type_check_fn,
-        name=f"{model.__class__.__name__}-{dagster_type_suffix}",
+        name=model.__class__.__name__,
         metadata={
             "schema": MetadataValue.table_schema(table_schema),
         },

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_patito.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_patito.py
@@ -139,17 +139,18 @@ def test_patito_type_check_happy_flow(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+        dagster_type=dagster_type,
     )
     def upstream() -> pl.DataFrame:
         return good_df
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "downstream"),
+        dagster_type=dagster_type,
     )
     def downstream(upstream: pl.DataFrame) -> pl.DataFrame:
         return upstream
@@ -163,10 +164,11 @@ def test_patito_type_check_bad_input(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_upstream"),
+        dagster_type=dagster_type,
     )
     def bad() -> pl.DataFrame:
         return bad_df
@@ -180,10 +182,11 @@ def test_patito_type_check_bad_output(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+        dagster_type=dagster_type,
     )
     def upstream() -> pl.DataFrame:
         return good_df
@@ -191,7 +194,7 @@ def test_patito_type_check_bad_output(
     @dg.asset(
         name="bad_downstream",
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_downstream"),
+        dagster_type=dagster_type,
     )
     def bad_downstream() -> pl.DataFrame:
         return bad_df
@@ -208,17 +211,18 @@ def test_patito_type_check_lazy_happy_path(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+        dagster_type=dagster_type,
     )
     def upstream() -> pl.LazyFrame:
         return good_df.lazy()
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "downstream"),
+        dagster_type=dagster_type,
     )
     def downstream(upstream: pl.LazyFrame) -> pl.LazyFrame:
         return upstream
@@ -233,10 +237,11 @@ def test_patito_type_check_lazy_bad_input(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_upstream"),
+        dagster_type=dagster_type,
     )
     def bad() -> pl.LazyFrame:
         return bad_df.lazy()
@@ -251,17 +256,18 @@ def test_patito_type_check_lazy_bad_output(
     io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
 ):
     manager, _ = io_manager_and_df
+    dagster_type = patito_model_to_dagster_type(TestingRecord)
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+        dagster_type=dagster_type,
     )
     def upstream() -> pl.LazyFrame:
         return good_df.lazy()
 
     @dg.asset(
         io_manager_def=manager,
-        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_downstream"),
+        dagster_type=dagster_type,
     )
     def bad_downstream() -> pl.LazyFrame:
         return bad_df.lazy()

--- a/python_modules/libraries/dagster-polars/dagster_polars_tests/test_patito.py
+++ b/python_modules/libraries/dagster-polars/dagster_polars_tests/test_patito.py
@@ -3,6 +3,7 @@ import patito as pt
 import polars as pl
 import pytest
 from dagster_polars import BasePolarsUPathIOManager
+from dagster_polars import patito_model_to_dagster_type
 
 
 class TestingRecord(pt.Model):
@@ -25,7 +26,9 @@ bad_df = pl.DataFrame(
 )
 
 
-def test_patito_eager_happy_path(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_eager_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -41,7 +44,9 @@ def test_patito_eager_happy_path(io_manager_and_df: tuple[BasePolarsUPathIOManag
         assert res.success
 
 
-def test_patito_eager_bad_output(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_eager_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -53,7 +58,9 @@ def test_patito_eager_bad_output(io_manager_and_df: tuple[BasePolarsUPathIOManag
         assert not res.success
 
 
-def test_patito_eager_bad_input(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_eager_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -65,12 +72,16 @@ def test_patito_eager_bad_input(io_manager_and_df: tuple[BasePolarsUPathIOManage
         return TestingRecord.DataFrame(bad_df)
 
     with dg.DagsterInstance.ephemeral() as instance:
-        res = dg.materialize([upstream, bad_downstream], instance=instance, raise_on_error=False)
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
         assert not res.success
 
 
 @pytest.mark.skip(reason="Lazy frame validation is not supported yet")
-def test_patito_lazy_happy_path(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_lazy_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -87,7 +98,9 @@ def test_patito_lazy_happy_path(io_manager_and_df: tuple[BasePolarsUPathIOManage
 
 
 @pytest.mark.skip(reason="Lazy frame validation is not supported yet")
-def test_patito_lazy_bad_output(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_lazy_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -100,7 +113,9 @@ def test_patito_lazy_bad_output(io_manager_and_df: tuple[BasePolarsUPathIOManage
 
 
 @pytest.mark.skip(reason="Lazy frame validation is not supported yet")
-def test_patito_lazy_bad_input(io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame]):
+def test_patito_lazy_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
     manager, _ = io_manager_and_df
 
     @dg.asset(io_manager_def=manager)
@@ -108,9 +123,151 @@ def test_patito_lazy_bad_input(io_manager_and_df: tuple[BasePolarsUPathIOManager
         return TestingRecord.DataFrame(good_df).lazy()
 
     @dg.asset(io_manager_def=manager)
-    def bad_downstream(good_upstream: TestingRecord.LazyFrame) -> TestingRecord.LazyFrame:
+    def bad_downstream(
+        good_upstream: TestingRecord.LazyFrame,
+    ) -> TestingRecord.LazyFrame:
         return TestingRecord.DataFrame(bad_df).lazy()
 
     with dg.DagsterInstance.ephemeral() as instance:
-        res = dg.materialize([upstream, bad_downstream], instance=instance, raise_on_error=False)
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+def test_patito_type_check_happy_flow(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+    )
+    def upstream() -> pl.DataFrame:
+        return good_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "downstream"),
+    )
+    def downstream(upstream: pl.DataFrame) -> pl.DataFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+def test_patito_type_check_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_upstream"),
+    )
+    def bad() -> pl.DataFrame:
+        return bad_df
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+def test_patito_type_check_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+    )
+    def upstream() -> pl.DataFrame:
+        return good_df
+
+    @dg.asset(
+        name="bad_downstream",
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_downstream"),
+    )
+    def bad_downstream() -> pl.DataFrame:
+        return bad_df
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_happy_path(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+    )
+    def upstream() -> pl.LazyFrame:
+        return good_df.lazy()
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "downstream"),
+    )
+    def downstream(upstream: pl.LazyFrame) -> pl.LazyFrame:
+        return upstream
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([upstream, downstream], instance=instance)
+        assert res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_bad_input(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_upstream"),
+    )
+    def bad() -> pl.LazyFrame:
+        return bad_df.lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize([bad], instance=instance, raise_on_error=False)
+        assert not res.success
+
+
+@pytest.mark.skip(reason="Lazy frame validation is not supported yet")
+def test_patito_type_check_lazy_bad_output(
+    io_manager_and_df: tuple[BasePolarsUPathIOManager, pl.DataFrame],
+):
+    manager, _ = io_manager_and_df
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "upstream"),
+    )
+    def upstream() -> pl.LazyFrame:
+        return good_df.lazy()
+
+    @dg.asset(
+        io_manager_def=manager,
+        dagster_type=patito_model_to_dagster_type(TestingRecord, "bad_downstream"),
+    )
+    def bad_downstream() -> pl.LazyFrame:
+        return bad_df.lazy()
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        res = dg.materialize(
+            [upstream, bad_downstream], instance=instance, raise_on_error=False
+        )
         assert not res.success


### PR DESCRIPTION
## Summary & Motivation
As discussed in [PR#28690](https://github.com/dagster-io/dagster/pull/28690), I added the functionality to insert patito type checks within the dagster type check.

## How I Tested These Changes
Created a few tests mimicking the structure of the other tests for patito.

## Remarks
Not a fan of how currently the asset name is passed to the `patito_model_to_dagster_type` function. Open to suggestions.
